### PR TITLE
Add support for saving files to a subdirectory within the Download folder (for Android)

### DIFF
--- a/android/src/main/kotlin/com/oodrive/downloadsfolder/DownloadsfolderPlugin.kt
+++ b/android/src/main/kotlin/com/oodrive/downloadsfolder/DownloadsfolderPlugin.kt
@@ -46,9 +46,10 @@ class DownloadsfolderPlugin : FlutterPlugin, MethodCallHandler {
                     val filePath = call.argument<String>("filePath")!!
                     val fileName = call.argument<String>("fileName")!!
                     val extension = call.argument<String?>("extension")
+                    val subDirectory = call.argument<String?>("subDirectory")
 
                     try {
-                        saveFileUsingMediaStore(context, filePath, fileName, extension)
+                        saveFileUsingMediaStore(context, filePath, fileName, extension, subDirectory)
                         result.success(true)
                     } catch (e: IOException) {
                         e.printStackTrace()
@@ -76,10 +77,18 @@ class DownloadsfolderPlugin : FlutterPlugin, MethodCallHandler {
     @TargetApi(Build.VERSION_CODES.Q)
     private fun saveFileUsingMediaStore(
         context: Context,
-        filePath: String,      // The path to the original file to be saved.
-        fileName: String,      // The name to be assigned to the saved file in MediaStore.
-        extension: String?    // An optional file extension for the saved file.
+        filePath: String,           // The path to the original file to be saved.
+        fileName: String,           // The name to be assigned to the saved file in MediaStore.
+        extension: String?,         // An optional file extension for the saved file.
+        subDirectory: String? = null   // An optional subDirectory for the saved file.
     ) {
+
+        val relativePath = if (!subDirectory.isNullOrEmpty()) {
+            "${Environment.DIRECTORY_DOWNLOADS}/${subDirectory.trim()}"
+        } else {
+            Environment.DIRECTORY_DOWNLOADS
+        }
+
         // Create a ContentValues object to specify the file attributes.
         val contentValues = ContentValues().apply {
             put(MediaStore.MediaColumns.DISPLAY_NAME, fileName)  // Set the display name.
@@ -87,10 +96,7 @@ class DownloadsfolderPlugin : FlutterPlugin, MethodCallHandler {
                 MediaStore.MediaColumns.MIME_TYPE,
                 getMimeTypeFromExtension(extension) ?: "application/octet-stream"
             )  // Set the MIME type.
-            put(
-                MediaStore.MediaColumns.RELATIVE_PATH,
-                Environment.DIRECTORY_DOWNLOADS
-            )  // Set the relative path.
+            put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)  // Set the relative path.
         }
 
         // Get the content resolver for the provided context.

--- a/lib/downloadsfolder.dart
+++ b/lib/downloadsfolder.dart
@@ -56,10 +56,10 @@ Future<Directory> getDownloadDirectory() =>
 /// by appending a suffix in the form of '_(copyNumber)' to the file name.
 /// The copy operation is retried until a unique name is found.
 Future<bool?> copyFileIntoDownloadFolder(String filePath, String fileName,
-        {File? file, String? desiredExtension}) =>
+        {File? file, String? desiredExtension, String? subDirectory}) =>
     DownloadsfolderPlatform.instance.copyFileIntoDownloadFolder(
         filePath, fileName,
-        file: file, desiredExtension: desiredExtension);
+        file: file, desiredExtension: desiredExtension, subDirectory: subDirectory);
 
 /// Opens the download folder on the device's file system.
 ///

--- a/lib/downloadsfolder_method_channel.dart
+++ b/lib/downloadsfolder_method_channel.dart
@@ -74,7 +74,7 @@ class MethodChannelDownloadsfolder extends DownloadsfolderPlatform {
 
   @override
   Future<bool?> copyFileIntoDownloadFolder(String filePath, String fileName,
-      {File? file, String? desiredExtension}) async {
+      {File? file, String? desiredExtension, String? subDirectory}) async {
     // Determine the Android SDK version (if it's an Android device).
     final androidSdkVersion =
         Platform.isAndroid ? await getCurrentAndroidSdkVersion() : 0;
@@ -89,10 +89,14 @@ class MethodChannelDownloadsfolder extends DownloadsfolderPlatform {
       return _saveFileUsingMediaStore(
           fileToCopy,
           basenameWithoutExtension(fileName),
-          desiredExtension ?? extension(fileToCopy.path));
+          desiredExtension ?? extension(fileToCopy.path),
+          subDirectory);
     }
     // Get the path to the download folder.
-    final folder = await getDownloadFolder();
+    final downloadFolder = await getDownloadFolder();
+    final folder = subDirectory != null
+        ? Directory('${downloadFolder.path}/${subDirectory.replaceAll(r'^/', '')}')
+        : downloadFolder;
 
     // Copy the file to the download folder with the specified file name and ensures a unique name to avoid overwriting existing files.
     await fileToCopy.copyTo(folder.path, fileName,
@@ -120,13 +124,14 @@ class MethodChannelDownloadsfolder extends DownloadsfolderPlatform {
   }
 
   Future<bool?> _saveFileUsingMediaStore(
-          File fileToCopy, String fileName, String desiredExtension) =>
+          File fileToCopy, String fileName, String desiredExtension, String? subDirectory) =>
       methodChannel.invokeMethod<bool>(
         'saveFileUsingMediaStore',
         {
           'filePath': fileToCopy.path,
           'fileName': fileName,
-          'extension': desiredExtension
+          'extension': desiredExtension,
+          'subDirectory': subDirectory,
         },
       );
 

--- a/lib/downloadsfolder_platform_interface.dart
+++ b/lib/downloadsfolder_platform_interface.dart
@@ -29,7 +29,7 @@ abstract class DownloadsfolderPlatform extends PlatformInterface {
       'getDownloadFolderPath() has not been implemented.');
 
   Future<bool?> copyFileIntoDownloadFolder(String filePath, String fileName,
-          {File? file, String? desiredExtension}) =>
+          {File? file, String? desiredExtension, String? subDirectory}) =>
       throw UnimplementedError(
           'copyFileIntoDownloadFolder() has not been implemented.');
 


### PR DESCRIPTION
Add support for saving files to a subdirectory within the Download folder (for Android).

The method copyFileIntoDownloadFolder() have now an optional param to indicated a destination subfolder.